### PR TITLE
gives paladins actual melee weapons because frok was evil + fixes head knight's rcw loadout

### DIFF
--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -225,7 +225,7 @@ Head Knight
 	loadout_options = list(
 	/datum/outfit/loadout/hka, //Sniper
 	/datum/outfit/loadout/hkb,	//AER14
-	/datum/outfit/loadout/hkb //RCW
+	/datum/outfit/loadout/hkc //RCW holy fuck can you at least get a path right kimi
 	)
 	outfit = /datum/outfit/job/bos/f13headknight
 

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -93,9 +93,9 @@ Head Paladin
 	exp_requirements = 600
 	
 	loadout_options = list(
-	/datum/outfit/loadout/hpa, //Laser Gatling
-	/datum/outfit/loadout/hpb, //Tribeam
-	/datum/outfit/loadout/hpc //14mm pistol, shield
+	/datum/outfit/loadout/hpa, //Laser Gatling, Super Sledge
+	/datum/outfit/loadout/hpb, //Tribeam, Powerfist
+	/datum/outfit/loadout/hpc //14mm pistol, Shield, Pre-war Ripper
 	)
 
 	outfit = /datum/outfit/job/bos/f13headpaladin
@@ -117,7 +117,6 @@ Head Paladin
 	neck = 			/obj/item/clothing/neck/mantle/bos/paladin
 	backpack_contents = list(
 		/obj/item/melee/onehanded/knife/hunting = 1,
-		/obj/item/melee/powered/ripper = 1,
 		/obj/item/gun/ballistic/automatic/pistol/n99/crusader = 1,
 		/obj/item/ammo_box/magazine/m10mm_adv/simple = 2,
 		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
@@ -127,14 +126,16 @@ Head Paladin
 	name = "Heavy Weapons Head Paladin"
 	backpack_contents = list(
 		/obj/item/minigunpack = 1,
-		/obj/item/stock_parts/cell/ammo/ecp = 3
+		/obj/item/stock_parts/cell/ammo/ecp = 3,
+		/obj/item/twohanded/sledgehammer/supersledge = 1
 		)
 
 /datum/outfit/loadout/hpb
 	name = "Frontline Head Paladin"
 	backpack_contents = list(
 		/obj/item/gun/energy/laser/scatter = 1,
-		/obj/item/stock_parts/cell/ammo/mfc = 3
+		/obj/item/stock_parts/cell/ammo/mfc = 3,
+		/obj/item/melee/unarmed/powerfist = 1
 		)
 		
 
@@ -143,7 +144,8 @@ Head Paladin
 	backpack_contents = list(
 		/obj/item/gun/ballistic/automatic/pistol/pistol14 = 1,
 		/obj/item/ammo_box/magazine/m14mm = 3,
-		/obj/item/shield/riot/bullet_proof = 1
+		/obj/item/shield/riot/bullet_proof = 1,
+		/obj/item/melee/powered/ripper/prewar = 1
 		)
 
 /datum/outfit/job/bos/f13headpaladin/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -329,7 +331,8 @@ Paladin
 	belt =	/obj/item/storage/belt/military/assault
 	neck =	/obj/item/clothing/neck/mantle/bos/paladin
 	backpack_contents = list(
-		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3
+		/obj/item/reagent_containers/hypospray/medipen/stimpak = 3,
+		/obj/item/melee/powered/ripper = 1,
 	)
 
 /datum/outfit/loadout/paladina

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -110,7 +110,7 @@ also: most hitscan weapons have more charge than their normal projectile counter
 /obj/item/ammo_casing/energy/laser/scatter/tribeam/hitscan
 	projectile_type = /obj/item/projectile/beam/laser/tribeam/hitscan
 	pellets = 3
-	variance = 45
+	variance = 22
 	select_name = "tribeam"
 	e_cost = 200 //10 shots
 


### PR DESCRIPTION
## About The Pull Request

head paladin has a melee weapon that changes with his loadout

paladins get rippers now because they had absolutely nothing before, could change to something else if you want it to.

~~should i also change the variance on the tribeam given that its 45 again and probably nigh-unusable?~~

also fixes the RCW loadout for head knight because someone pathed it wrong

halves the variance on the tribeam from 45 to 22

## Why It's Good For The Game

ah yes, not having a fallback weapon is indeed fun and balanced.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->


## Changelog
<!-- This is mostly optional for small Pull Requests, but if you value being credited for your work in-game be sure to fill it out. To opt-out, remove everything below including the start and end :cl: brackets. -->

<!-- If your Pull Request includes a minor single line variable edit, probably do not fill out this changelog. -->
<!-- However, if your pull request includes massive or immediately noticeable changes, briefly describe those changes in some way in this changelog. -->

:cl:
balance: Paladins given melee weapons.
/:cl:

