### PR TITLE
disabling of romerol zombies

### DIFF
--- a/code/datums/diseases/advance/symptoms/flesh_eating.dm
+++ b/code/datums/diseases/advance/symptoms/flesh_eating.dm
@@ -132,6 +132,4 @@ Bonus
 	M.adjustBruteLoss(get_damage)
 	if(chems)
 		M.reagents.add_reagent_list(list(/datum/reagent/toxin/heparin = 2, /datum/reagent/toxin/lipolicide = 2))
-	if(zombie)
-		M.reagents.add_reagent(/datum/reagent/romerol, 1)
 	return 1

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -323,7 +323,6 @@
 	new/obj/item/toy/crayon/rainbow(src)
 
 /obj/item/storage/box/syndie_kit/romerol/PopulateContents()
-	new /obj/item/reagent_containers/glass/bottle/romerol(src)
 	new /obj/item/reagent_containers/syringe(src)
 	new /obj/item/reagent_containers/dropper(src)
 	new /obj/item/paper/guides/antag/romerol_instructions(src)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1,35 +1,3 @@
-Skip to content
-Search or jump to…
-Pull requests
-Issues
-Codespaces
-Marketplace
-Explore
- 
-@BrotherHangyul 
-Fallout-Big-Iron
-/
-Big-Iron
-Public
-Fork your own copy of Fallout-Big-Iron/Big-Iron
-Code
-Issues
-6
-Pull requests
-16
-Actions
-Projects
-Security
-Insights
-Big-Iron/code/modules/reagents/chemistry/reagents/other_reagents.dm
-@BadAtThisGame302
-BadAtThisGame302 Massive Code Fixes
-Latest commit f4682d9 5 days ago
- History
- 74 contributors
-@Poojawa@silicons@Ghommie@Trilbyspaceclone@Putnam3145@CitadelStationBot@Arturlang@timothyteakettle@LetterJay@AlexPieNoticeMe@Iatots@Thalpy
-2827 lines (2445 sloc)  97.9 KB
-
 /datum/reagent/blood
 	data = list("donor"=null,"viruses"=null,"blood_DNA"=null, "bloodcolor" = BLOOD_COLOR_HUMAN, "blood_type"= null,"resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null,"cloneable"=null,"factions"=null,"quirks"=null)
 	name = "Blood"
@@ -2854,18 +2822,3 @@ Latest commit f4682d9 5 days ago
 /datum/reagent/nutracid/on_mob_life(mob/living/carbon/M)
 	M.adjust_nutrition(-5)
 	..()
-Footer
-© 2023 GitHub, Inc.
-Footer navigation
-Terms
-Privacy
-Security
-Status
-Docs
-Contact GitHub
-Pricing
-API
-Training
-Blog
-About
-Big-Iron/other_reagents.dm at master · Fallout-Big-Iron/Big-Iron

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1,3 +1,35 @@
+Skip to content
+Search or jump to…
+Pull requests
+Issues
+Codespaces
+Marketplace
+Explore
+ 
+@BrotherHangyul 
+Fallout-Big-Iron
+/
+Big-Iron
+Public
+Fork your own copy of Fallout-Big-Iron/Big-Iron
+Code
+Issues
+6
+Pull requests
+16
+Actions
+Projects
+Security
+Insights
+Big-Iron/code/modules/reagents/chemistry/reagents/other_reagents.dm
+@BadAtThisGame302
+BadAtThisGame302 Massive Code Fixes
+Latest commit f4682d9 5 days ago
+ History
+ 74 contributors
+@Poojawa@silicons@Ghommie@Trilbyspaceclone@Putnam3145@CitadelStationBot@Arturlang@timothyteakettle@LetterJay@AlexPieNoticeMe@Iatots@Thalpy
+2827 lines (2445 sloc)  97.9 KB
+
 /datum/reagent/blood
 	data = list("donor"=null,"viruses"=null,"blood_DNA"=null, "bloodcolor" = BLOOD_COLOR_HUMAN, "blood_type"= null,"resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null,"cloneable"=null,"factions"=null,"quirks"=null)
 	name = "Blood"
@@ -2277,7 +2309,7 @@
 	..()
 
 //Misc reagents
-
+/*
 /datum/reagent/romerol
 	name = "Romerol"
 	// the REAL zombie powder
@@ -2300,7 +2332,7 @@
 		var/obj/item/organ/zombie_infection/nodamage/ZI = new()
 		ZI.Insert(H)
 	..()
-
+*/
 /datum/reagent/magillitis
 	name = "Magillitis"
 	description = "An experimental serum which causes rapid muscular growth in Hominidae. Side-affects may include hypertrichosis, violent outbursts, and an unending affinity for bananas."
@@ -2322,7 +2354,6 @@
 	var/current_size = RESIZE_DEFAULT_SIZE
 	value = REAGENT_VALUE_COMMON
 	taste_description = "bitterness" // apparently what viagra tastes like
-
 /datum/reagent/growthserum/on_mob_life(mob/living/carbon/H)
 	var/newsize = current_size
 	switch(volume)
@@ -2336,12 +2367,10 @@
 			newsize = 2.5*RESIZE_DEFAULT_SIZE
 		if(200 to INFINITY)
 			newsize = 3.5*RESIZE_DEFAULT_SIZE
-
 	H.resize = newsize/current_size
 	current_size = newsize
 	H.update_transform()
 	..()
-
 /datum/reagent/growthserum/on_mob_end_metabolize(mob/living/M)
 	M.resize = RESIZE_DEFAULT_SIZE/current_size
 	current_size = RESIZE_DEFAULT_SIZE
@@ -2825,3 +2854,18 @@
 /datum/reagent/nutracid/on_mob_life(mob/living/carbon/M)
 	M.adjust_nutrition(-5)
 	..()
+Footer
+© 2023 GitHub, Inc.
+Footer navigation
+Terms
+Privacy
+Security
+Status
+Docs
+Contact GitHub
+Pricing
+API
+Training
+Blog
+About
+Big-Iron/other_reagents.dm at master · Fallout-Big-Iron/Big-Iron

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -232,12 +232,12 @@
 	list_reagents = list(/datum/reagent/fermi/zeolites = 30)
 
 // Viro bottles
-
+/*
 /obj/item/reagent_containers/glass/bottle/romerol
 	name = "romerol bottle"
 	desc = "A small bottle of Romerol. The REAL zombie powder."
 	list_reagents = list(/datum/reagent/romerol = 30)
-
+*/
 /obj/item/reagent_containers/glass/bottle/random_virus
 	name = "Experimental disease culture bottle"
 	desc = "A small bottle. Contains an untested viral culture in synthblood medium."

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -863,14 +863,14 @@
 	id = "surgery_ligament_reinforcement"
 	surgery = /datum/surgery/advanced/bioware/ligament_reinforcement
 	research_icon_state = "surgery_chest"
-
+/*
 /datum/design/surgery/necrotic_revival
 	name = "Necrotic Revival"
 	desc = "An experimental surgical procedure that stimulates the growth of a Romerol tumor inside the patient's brain. Requires rezadone."
 	id = "surgery_zombie"
 	surgery = /datum/surgery/advanced/necrotic_revival
 	research_icon_state = "surgery_head"
-
+*/
 /////////////////////////////////////////
 ////////////Medical Prosthetics//////////
 /////////////////////////////////////////

--- a/code/modules/research/techweb/nodes/medical_nodes.dm
+++ b/code/modules/research/techweb/nodes/medical_nodes.dm
@@ -148,5 +148,5 @@
 	display_name = "Alien Surgery"
 	description = "Abductors did nothing wrong."
 	prereq_ids = list("exp_surgery", "alientech")
-	design_ids = list("surgery_brainwashing","surgery_zombie", "surgery_ext_dissection", "surgery_heal_combo_upgrade_femto")
+	design_ids = list("surgery_brainwashing", "surgery_ext_dissection", "surgery_heal_combo_upgrade_femto")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)

--- a/code/modules/surgery/advanced/necrotic_revival.dm
+++ b/code/modules/surgery/advanced/necrotic_revival.dm
@@ -1,3 +1,4 @@
+/*
 /datum/surgery/advanced/necrotic_revival
 	name = "Necrotic Revival"
 	desc = "An experimental surgical procedure that stimulates the growth of a Romerol tumor inside the patient's brain. Requires rezadone."
@@ -36,3 +37,4 @@
 		var/obj/item/organ/zombie_infection/ZI = new()
 		ZI.Insert(target)
 	return TRUE
+*/


### PR DESCRIPTION
lore reasons: doesn't fit in with fallout. at all.

game balance reasons: one-hit "you're dead" zombies are bad for the game.

staff reasons: it's getting harder for staff to police these due to a rise of no-escing romerol zombies. conflicting FTs, the fact that this isn't widespread enough of an issue to get an official ruling against it but also abused enough that mods/admins are getting angry about it, etc.

basically a QoL change for staff and for the greater good of the server.