### PR TITLE
Small fix

### DIFF
--- a/_maps/map_files/Pahrump/Pahrump-Above-3.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Above-3.dmm
@@ -157,6 +157,12 @@
 	icon_state = "darkrusty"
 	},
 /area/f13/building)
+"aC" = (
+/obj/effect/turf_decal/shadow/floor{
+	dir = 8
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "aD" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing/corner,
@@ -401,7 +407,9 @@
 /obj/structure/railing/handrail/legion/underlayer{
 	dir = 5
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
+	},
 /area/f13/wasteland)
 "bp" = (
 /obj/structure/table,
@@ -521,6 +529,11 @@
 /obj/machinery/microwave/stove,
 /turf/open/floor/plasteel/f13/vault_floor/blue/white/whitebluechess,
 /area/f13/store)
+"bH" = (
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4-broken"
+	},
+/area/f13/legion)
 "bJ" = (
 /obj/structure/railing{
 	color = "#A47449";
@@ -667,6 +680,12 @@
 /obj/structure/junk/small/table,
 /turf/open/floor/carpet/blue,
 /area/f13/village)
+"cc" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
+/area/f13/legion)
 "cd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood/fancy/black,
@@ -805,6 +824,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"cw" = (
+/obj/structure/bed/wooden,
+/obj/effect/landmark/start/f13/vetlegionary,
+/obj/item/bedsheet/blanket,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
+	},
+/area/f13/legion)
 "cy" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -973,7 +1000,9 @@
 	},
 /obj/effect/turf_decal/shadow/floor,
 /obj/effect/shadow/wall,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
 /area/f13/legion)
 "cY" = (
 /obj/structure/closet/cabinet,
@@ -1009,7 +1038,9 @@
 /obj/item/toy/cards/deck,
 /obj/effect/turf_decal/shadow/floor,
 /obj/effect/shadow/wall,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3"
+	},
 /area/f13/legion)
 "de" = (
 /turf/open/transparent/openspace,
@@ -1079,7 +1110,9 @@
 /obj/item/reagent_containers/food/drinks/bottle/f13nukacola,
 /obj/effect/turf_decal/shadow/floor,
 /obj/effect/shadow/wall,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
 /area/f13/legion)
 "dn" = (
 /obj/structure/table,
@@ -1138,6 +1171,14 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/clinic)
+"dv" = (
+/obj/structure/railing/handrail/legion/underlayer{
+	dir = 1
+	},
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3"
+	},
+/area/f13/wasteland)
 "dw" = (
 /obj/structure/window/fulltile/wood/broken,
 /obj/structure/decoration/rag,
@@ -1222,7 +1263,9 @@
 /obj/structure/railing/handrail/legion{
 	dir = 4
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
 /area/f13/wasteland)
 "dI" = (
 /turf/open/floor/carpet/black,
@@ -1675,6 +1718,12 @@
 /obj/effect/turf_decal/stripes/white/box,
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"fd" = (
+/obj/structure/railing/handrail/legion/overlayer,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
+	},
+/area/f13/wasteland)
 "fe" = (
 /obj/structure/chair/stool,
 /obj/structure/destructible/tribal_torch/wall/lit{
@@ -1938,8 +1987,8 @@
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
 "fQ" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3-broken"
 	},
 /area/f13/wasteland)
 "fR" = (
@@ -2118,7 +2167,9 @@
 	},
 /obj/effect/turf_decal/shadow/floor,
 /obj/effect/shadow/wall,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3"
+	},
 /area/f13/legion)
 "gq" = (
 /obj/structure/railing{
@@ -2560,11 +2611,6 @@
 "hF" = (
 /turf/open/floor/plasteel/f13/vault_floor/blue/white/whitebluechess,
 /area/f13/store)
-"hI" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood1-broken"
-	},
-/area/f13/wasteland)
 "hJ" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small{
@@ -2618,7 +2664,9 @@
 /area/f13/wasteland)
 "hT" = (
 /obj/effect/landmark/start/f13/frumentarius,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
 /area/f13/legion)
 "hU" = (
 /obj/effect/decal/cleanable/dirt{
@@ -3105,12 +3153,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/f13/store)
-"jn" = (
-/obj/structure/railing/handrail/legion/overlayer,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken"
-	},
-/area/f13/wasteland)
 "jp" = (
 /turf/open/floor/carpet/arcade,
 /area/f13/ncr)
@@ -3135,6 +3177,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/dark/darksolid,
 /area/f13/ncr)
+"jt" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3"
+	},
+/area/f13/legion)
 "ju" = (
 /obj/structure/closet/crate/trashcart,
 /obj/effect/decal/cleanable/dirt,
@@ -3605,6 +3655,12 @@
 	icon_state = "greendirtyfull"
 	},
 /area/f13/building)
+"kB" = (
+/obj/item/melee/onehanded/machete/training,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
+	},
+/area/f13/wasteland)
 "kC" = (
 /turf/closed/mineral/random/low_chance,
 /area/f13/caves)
@@ -3690,9 +3746,7 @@
 /obj/structure/railing/handrail/legion{
 	dir = 4
 	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
-	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/wasteland)
 "kQ" = (
 /obj/structure/table/wood,
@@ -3960,6 +4014,11 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/clinic)
+"lF" = (
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2-broken"
+	},
+/area/f13/wasteland)
 "lG" = (
 /obj/structure/window/fulltile/wood,
 /obj/structure/barricade/bars,
@@ -4291,8 +4350,8 @@
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/shadow/floor,
 /obj/effect/shadow/wall,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood2-broken"
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
 	},
 /area/f13/legion)
 "mC" = (
@@ -4690,6 +4749,14 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
+"nG" = (
+/obj/structure/railing/handrail/legion{
+	dir = 8
+	},
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3"
+	},
+/area/f13/wasteland)
 "nH" = (
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/caves)
@@ -4705,7 +4772,9 @@
 	},
 /obj/effect/turf_decal/shadow/floor,
 /obj/effect/shadow/wall,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
 /area/f13/legion)
 "nL" = (
 /obj/structure/railing{
@@ -4714,6 +4783,14 @@
 	},
 /turf/open/indestructible/ground/outside/woodalt,
 /area/f13/raiders)
+"nM" = (
+/obj/structure/bed/wooden,
+/obj/effect/landmark/start/f13/vetlegionary,
+/obj/item/bedsheet/blanket,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
+/area/f13/legion)
 "nN" = (
 /obj/structure/chair/sofa/corner,
 /obj/effect/decal/cleanable/dirt{
@@ -4993,7 +5070,9 @@
 	pixel_x = -5
 	},
 /obj/effect/shadow/wall,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
 /area/f13/legion)
 "oz" = (
 /obj/structure/rack,
@@ -5134,6 +5213,12 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/floor/floorsolid,
 /area/f13/building)
+"oW" = (
+/obj/structure/railing/handrail/legion/underlayer{
+	dir = 1
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/wasteland)
 "oX" = (
 /obj/structure/fluff/railing/corner{
 	dir = 1
@@ -5241,6 +5326,22 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/clinic)
+"pk" = (
+/obj/effect/turf_decal/shadow/floor{
+	dir = 4
+	},
+/obj/effect/shadow/wall{
+	pixel_x = -64;
+	pixel_y = 0
+	},
+/obj/effect/shadow/wall{
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3"
+	},
+/area/f13/legion)
 "pl" = (
 /obj/structure/simple_door/room,
 /turf/open/floor/f13/wood,
@@ -5858,7 +5959,9 @@
 	},
 /obj/effect/turf_decal/shadow/floor,
 /obj/effect/shadow/wall,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3"
+	},
 /area/f13/legion)
 "qS" = (
 /obj/effect/decal/cleanable/dirt{
@@ -5973,7 +6076,9 @@
 "rf" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/shadow/floor,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
 /area/f13/legion)
 "rg" = (
 /obj/structure/simple_door/room{
@@ -6056,7 +6161,9 @@
 /obj/structure/table/wood,
 /obj/structure/bedsheetbin,
 /obj/effect/turf_decal/shadow/floor,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3"
+	},
 /area/f13/legion)
 "rs" = (
 /obj/effect/decal/cleanable/dirt{
@@ -6081,7 +6188,9 @@
 	pixel_y = 6;
 	plane = -3.8
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
 /area/f13/wasteland)
 "ru" = (
 /obj/structure/bonfire/prelit,
@@ -6102,7 +6211,9 @@
 	},
 /obj/effect/turf_decal/shadow/floor,
 /obj/effect/shadow/wall,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
+	},
 /area/f13/legion)
 "rw" = (
 /obj/structure/rack,
@@ -6222,7 +6333,9 @@
 	},
 /obj/effect/turf_decal/shadow/floor,
 /obj/effect/shadow/wall,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
 /area/f13/legion)
 "rM" = (
 /obj/machinery/light/small,
@@ -6289,6 +6402,12 @@
 	},
 /turf/open/floor/f13,
 /area/f13/brotherhood/surface)
+"sa" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3"
+	},
+/area/f13/legion)
 "sb" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/trash/tray,
@@ -6426,7 +6545,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/shadow/floor,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
 /area/f13/legion)
 "su" = (
 /obj/structure/table,
@@ -6478,7 +6599,9 @@
 	},
 /obj/effect/turf_decal/shadow/floor,
 /obj/effect/shadow/wall,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3"
+	},
 /area/f13/legion)
 "sC" = (
 /obj/structure/table/reinforced,
@@ -6559,7 +6682,9 @@
 /obj/effect/turf_decal/shadow/floor{
 	dir = 8
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3"
+	},
 /area/f13/legion)
 "sP" = (
 /obj/structure/bookcase,
@@ -6646,7 +6771,9 @@
 	},
 /obj/effect/turf_decal/shadow/floor,
 /obj/effect/shadow/wall,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
+	},
 /area/f13/legion)
 "tc" = (
 /obj/effect/decal/cleanable/dirt{
@@ -7201,9 +7328,7 @@
 /area/f13/caves)
 "uy" = (
 /obj/structure/railing/handrail/legion/overlayer,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood1-broken"
-	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/wasteland)
 "uz" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7404,6 +7529,12 @@
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood/house,
+/area/f13/wasteland)
+"uZ" = (
+/obj/structure/railing/handrail/legion{
+	dir = 8
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/wasteland)
 "va" = (
 /obj/structure/table,
@@ -7791,7 +7922,9 @@
 	dir = 4;
 	pixel_x = -17
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3"
+	},
 /area/f13/legion)
 "wi" = (
 /obj/structure/closet/crate/bin/trashbin,
@@ -7816,7 +7949,7 @@
 /area/f13/ncr)
 "wl" = (
 /obj/effect/landmark/start/f13/campfollower,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "wn" = (
 /obj/item/kirbyplants/dead{
@@ -7954,7 +8087,9 @@
 	pixel_x = 5
 	},
 /obj/effect/shadow/wall,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
+	},
 /area/f13/legion)
 "wE" = (
 /obj/structure/curtain{
@@ -7997,6 +8132,17 @@
 	},
 /turf/closed/wall/f13/wood,
 /area/f13/caves)
+"wL" = (
+/obj/structure/chair/comfy/bench,
+/obj/structure/decoration/legion/chains{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/shadow/floor,
+/obj/effect/shadow/wall,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3"
+	},
+/area/f13/legion)
 "wM" = (
 /obj/item/kirbyplants/random{
 	pixel_y = 8
@@ -8005,7 +8151,9 @@
 /area/f13/ncr)
 "wN" = (
 /obj/structure/closet/cabinet/anchored,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
 /area/f13/legion)
 "wO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8102,6 +8250,12 @@
 	icon_state = "bluedirtychess2"
 	},
 /area/f13/caves)
+"xc" = (
+/obj/effect/turf_decal/shadow/floor{
+	dir = 4
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "xd" = (
 /obj/structure/decoration/rag{
 	icon_state = "skin"
@@ -9081,13 +9235,20 @@
 /area/f13/building)
 "zY" = (
 /obj/item/kirbyplants/random,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
 /area/f13/legion)
 "zZ" = (
 /obj/structure/barricade/wooden,
 /obj/structure/decoration/rag,
 /turf/closed/wall/f13/wood,
 /area/f13/raiders)
+"Aa" = (
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor1-broken"
+	},
+/area/f13/wasteland)
 "Ac" = (
 /obj/structure/wreck/trash/machinepile,
 /turf/open/floor/wood/f13/old,
@@ -9333,7 +9494,9 @@
 	light_power = 0.8;
 	pixel_y = -5
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3"
+	},
 /area/f13/legion)
 "AS" = (
 /obj/structure/simple_door/room,
@@ -9402,7 +9565,7 @@
 /obj/effect/turf_decal/shadow/floor{
 	dir = 4
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "Bb" = (
 /obj/structure/table/wood,
@@ -9419,7 +9582,9 @@
 /area/f13/ncr)
 "Be" = (
 /obj/item/melee/onehanded/machete/training,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
 /area/f13/wasteland)
 "Bf" = (
 /obj/structure/chair/stool{
@@ -9463,7 +9628,9 @@
 	can_be_unanchored = 1;
 	dir = 4
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
 /area/f13/legion)
 "Bk" = (
 /obj/structure/closet/locker,
@@ -9717,7 +9884,7 @@
 	},
 /obj/effect/turf_decal/shadow/floor,
 /obj/effect/shadow/wall,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "Ca" = (
 /obj/structure/table,
@@ -9753,7 +9920,9 @@
 	},
 /obj/effect/turf_decal/shadow/floor,
 /obj/effect/shadow/wall,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3"
+	},
 /area/f13/legion)
 "Cd" = (
 /obj/structure/chair/sofa/left{
@@ -9893,7 +10062,9 @@
 	},
 /obj/item/reagent_containers/food/snacks/breadhard,
 /obj/item/reagent_containers/food/snacks/breadhard,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
+	},
 /area/f13/legion)
 "Cz" = (
 /obj/machinery/light/small{
@@ -9966,12 +10137,18 @@
 	dir = 1
 	},
 /area/f13/brotherhood/surface)
+"CJ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3"
+	},
+/area/f13/legion)
 "CL" = (
 /obj/effect/turf_decal/shadow/floor{
 	dir = 1
 	},
 /obj/effect/turf_decal/shadow/floor,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "CM" = (
 /turf/open/floor/carpet/black,
@@ -10007,7 +10184,9 @@
 /area/f13/building)
 "CR" = (
 /obj/structure/railing/handrail/legion/overlayer,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
 /area/f13/wasteland)
 "CS" = (
 /obj/structure/railing{
@@ -10075,7 +10254,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/shadow/floor,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "Da" = (
 /obj/structure/chair/wood/fancy{
@@ -10125,7 +10304,9 @@
 	},
 /obj/structure/chair/comfy/brown,
 /obj/effect/shadow/wall,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
 /area/f13/legion)
 "Dj" = (
 /obj/structure/guncase,
@@ -10245,7 +10426,9 @@
 /obj/item/paper/bitterdrink,
 /obj/effect/shadow/wall,
 /obj/item/paper/hydra,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3"
+	},
 /area/f13/legion)
 "Dz" = (
 /obj/effect/decal/cleanable/dirt{
@@ -10301,7 +10484,9 @@
 /obj/structure/chair/wood{
 	dir = 1
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
 /area/f13/legion)
 "DH" = (
 /turf/closed/wall/f13/wood/interior,
@@ -10338,7 +10523,9 @@
 /area/f13/building)
 "DO" = (
 /obj/structure/chair/wood,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
+	},
 /area/f13/legion)
 "DP" = (
 /obj/effect/decal/cleanable/dirt{
@@ -10382,7 +10569,9 @@
 /area/f13/caves)
 "DW" = (
 /obj/structure/simple_door/interior,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
 /area/f13/legion)
 "DX" = (
 /obj/structure/easel,
@@ -10714,7 +10903,9 @@
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
 /obj/effect/shadow/wall,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
+	},
 /area/f13/legion)
 "Ff" = (
 /obj/structure/decoration/rag{
@@ -10932,7 +11123,9 @@
 "FG" = (
 /obj/effect/turf_decal/shadow/floor,
 /obj/effect/shadow/wall,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
 /area/f13/legion)
 "FH" = (
 /obj/machinery/light{
@@ -11005,7 +11198,9 @@
 /obj/effect/turf_decal/shadow/floor{
 	dir = 4
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
 /area/f13/legion)
 "FS" = (
 /obj/structure/window/fulltile/wood,
@@ -11028,8 +11223,8 @@
 /turf/open/indestructible/ground/outside/roof,
 /area/f13/ncr)
 "FV" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken"
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3"
 	},
 /area/f13/legion)
 "FX" = (
@@ -11959,6 +12154,16 @@
 	dir = 1
 	},
 /area/f13/brotherhood/surface)
+"IC" = (
+/obj/effect/turf_decal/shadow/floor{
+	dir = 1
+	},
+/obj/effect/turf_decal/shadow/floor,
+/obj/effect/shadow/wall,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
+	},
+/area/f13/legion)
 "ID" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -12171,6 +12376,13 @@
 	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
+"Jt" = (
+/obj/structure/chair/bench{
+	dir = 4;
+	pixel_x = -17
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "Ju" = (
 /obj/structure/chair,
 /turf/open/floor/f13{
@@ -12255,7 +12467,7 @@
 /obj/structure/railing/handrail/legion/overlayer{
 	dir = 10
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/wasteland)
 "JH" = (
 /obj/structure/table/wood,
@@ -12410,7 +12622,9 @@
 	dir = 4
 	},
 /obj/effect/shadow/wall,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
 /area/f13/legion)
 "Ke" = (
 /obj/structure/bookcase,
@@ -12725,7 +12939,9 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
+	},
 /area/f13/legion)
 "Lb" = (
 /obj/structure/window/fulltile/ruins{
@@ -12797,7 +13013,9 @@
 /obj/effect/turf_decal/shadow/floor{
 	dir = 4
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
+	},
 /area/f13/legion)
 "Ll" = (
 /obj/structure/table/wood,
@@ -12822,9 +13040,7 @@
 	},
 /area/f13/clinic)
 "Lo" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken"
-	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "Lp" = (
 /obj/structure/barricade/wooden/planks/pregame,
@@ -12999,7 +13215,9 @@
 /obj/structure/railing/handrail/legion/underlayer{
 	dir = 1
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
 /area/f13/wasteland)
 "LR" = (
 /obj/structure/decoration/rag,
@@ -13038,11 +13256,13 @@
 /obj/structure/railing/handrail/legion/underlayer{
 	dir = 9
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
+	},
 /area/f13/wasteland)
 "Mb" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood4-broken"
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
 	},
 /area/f13/wasteland)
 "Md" = (
@@ -13258,6 +13478,14 @@
 	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"MK" = (
+/obj/effect/turf_decal/shadow/floor{
+	dir = 4
+	},
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3"
+	},
+/area/f13/legion)
 "MM" = (
 /obj/structure/barricade/wooden,
 /obj/structure/fence/wooden{
@@ -13477,8 +13705,8 @@
 /turf/open/floor/plasteel/f13/vault_floor/white,
 /area/f13/clinic)
 "Nu" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken"
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4-broken"
 	},
 /area/f13/wasteland)
 "Nw" = (
@@ -13566,7 +13794,9 @@
 "NP" = (
 /obj/structure/table/wood,
 /obj/item/taperecorder,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3"
+	},
 /area/f13/legion)
 "NQ" = (
 /obj/structure/bookcase,
@@ -13608,7 +13838,9 @@
 "NY" = (
 /obj/structure/table/wood,
 /obj/item/warpaint_bowl,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
 /area/f13/legion)
 "NZ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13717,7 +13949,9 @@
 /area/f13/caves)
 "Oq" = (
 /obj/structure/table/wood,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
+	},
 /area/f13/legion)
 "Or" = (
 /obj/effect/turf_decal/shadow/floor{
@@ -13727,7 +13961,7 @@
 	dir = 4;
 	pixel_x = -33
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "Os" = (
 /obj/structure/window/fulltile/house{
@@ -13862,8 +14096,8 @@
 /obj/structure/bed/wooden,
 /obj/effect/landmark/start/f13/vetlegionary,
 /obj/item/bedsheet/blanket,
-/turf/open/floor/f13/wood{
-	icon_state = "housewood3-broken"
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3"
 	},
 /area/f13/legion)
 "OO" = (
@@ -13895,7 +14129,9 @@
 /obj/structure/destructible/tribal_torch/wall/lit{
 	light_power = 0.6
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
 /area/f13/legion)
 "OS" = (
 /obj/effect/decal/cleanable/dirt{
@@ -13935,6 +14171,17 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/cazador_meat,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/wasteland)
+"OX" = (
+/obj/structure/chair/comfy/bench,
+/obj/structure/decoration/legion/chains{
+	pixel_y = 28
+	},
+/obj/effect/turf_decal/shadow/floor,
+/obj/effect/shadow/wall,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
+	},
+/area/f13/legion)
 "OY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -13986,7 +14233,9 @@
 /obj/item/paper/natural,
 /obj/item/folder/red,
 /obj/item/pen/charcoal,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
+	},
 /area/f13/legion)
 "Pe" = (
 /obj/structure/chair/office{
@@ -14111,7 +14360,9 @@
 /obj/structure/railing/handrail/legion/entrance{
 	dir = 1
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
 /area/f13/wasteland)
 "PB" = (
 /obj/structure/table,
@@ -14154,7 +14405,9 @@
 /obj/effect/turf_decal/shadow/floor{
 	dir = 8
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
 /area/f13/legion)
 "PF" = (
 /obj/structure/table/wood/poker,
@@ -14279,7 +14532,9 @@
 /area/f13/clinic)
 "Qb" = (
 /obj/machinery/door/unpowered/securedoor/legion,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
+	},
 /area/f13/legion)
 "Qc" = (
 /obj/structure/table/snooker,
@@ -14390,7 +14645,7 @@
 /obj/effect/turf_decal/shadow/floor{
 	dir = 4
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "Qt" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14401,6 +14656,12 @@
 	icon_state = "whitedirtysolid"
 	},
 /area/f13/clinic)
+"Qv" = (
+/obj/structure/railing/handrail/legion/overlayer,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3"
+	},
+/area/f13/wasteland)
 "Qw" = (
 /obj/structure/decoration/rag,
 /obj/structure/barricade/wooden,
@@ -14647,7 +14908,9 @@
 /obj/effect/turf_decal/shadow/floor{
 	dir = 4
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
+	},
 /area/f13/legion)
 "Rg" = (
 /obj/effect/decal/cleanable/dirt{
@@ -14763,11 +15026,9 @@
 /turf/open/floor/carpet/blue,
 /area/f13/village)
 "Rw" = (
-/obj/effect/turf_decal/shadow/floor{
-	dir = 8
-	},
-/turf/open/floor/f13/wood{
-	icon_state = "housewood1-broken"
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
 	},
 /area/f13/legion)
 "Rx" = (
@@ -14781,14 +15042,10 @@
 /turf/open/floor/plasteel/f13/vault_floor/purple,
 /area/f13/clinic)
 "Rz" = (
-/obj/effect/turf_decal/shadow/floor{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
 	},
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 4;
-	light_power = 0.8
-	},
-/turf/open/floor/f13/wood,
 /area/f13/legion)
 "RA" = (
 /obj/structure/mopbucket,
@@ -14846,7 +15103,9 @@
 	pixel_y = 6;
 	plane = -3.8
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
 /area/f13/wasteland)
 "RK" = (
 /obj/structure/table/booth,
@@ -14909,7 +15168,7 @@
 /area/f13/brotherhood/surface)
 "RU" = (
 /obj/structure/simple_door/glass,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "RV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -14928,7 +15187,9 @@
 	pixel_x = 1
 	},
 /obj/effect/shadow/wall,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3"
+	},
 /area/f13/legion)
 "RX" = (
 /obj/structure/table/wood,
@@ -15058,6 +15319,11 @@
 /obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"Sq" = (
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
+	},
+/area/f13/legion)
 "Sr" = (
 /obj/structure/table/wood/poker{
 	name = "felt table"
@@ -15091,7 +15357,9 @@
 /obj/machinery/computer/card/legion,
 /obj/structure/table/wood,
 /obj/effect/shadow/wall,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3"
+	},
 /area/f13/legion)
 "Sx" = (
 /obj/structure/junk/locker,
@@ -15170,6 +15438,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/carpet,
 /area/f13/building)
+"SR" = (
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
+/area/f13/legion)
 "SS" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -15239,6 +15512,12 @@
 	sunlight_state = 1
 	},
 /area/f13/wasteland)
+"Te" = (
+/obj/structure/destructible/tribal_torch/wall/lit{
+	light_power = 0.6
+	},
+/turf/open/floor/wood/f13/oak,
+/area/f13/legion)
 "Tf" = (
 /obj/structure/decoration/rag,
 /obj/effect/decal/cleanable/dirt,
@@ -15313,6 +15592,11 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
 /area/f13/legion)
+"Ts" = (
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3"
+	},
+/area/f13/wasteland)
 "Tt" = (
 /obj/structure/table/wood/settler,
 /obj/item/reagent_containers/hypospray/medipen/stimpak,
@@ -15495,9 +15779,8 @@
 	},
 /area/f13/brotherhood/surface)
 "TW" = (
-/turf/open/floor/f13/wood{
-	icon_state = "housewood1-broken"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "TX" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -15651,7 +15934,9 @@
 /obj/structure/railing/handrail/legion/overlayer{
 	dir = 6
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3"
+	},
 /area/f13/wasteland)
 "Ut" = (
 /obj/structure/table/wood/poker,
@@ -15681,7 +15966,7 @@
 	dir = 8
 	},
 /obj/effect/shadow/wall,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "Ux" = (
 /obj/structure/window/fulltile/house{
@@ -15692,6 +15977,15 @@
 	icon_state = "skin"
 	},
 /turf/open/floor/f13/wood,
+/area/f13/legion)
+"Uy" = (
+/obj/structure/chair/comfy/bench{
+	dir = 4
+	},
+/obj/effect/turf_decal/shadow/floor{
+	dir = 4
+	},
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "Uz" = (
 /obj/structure/closet/crate/trashcart,
@@ -15748,7 +16042,6 @@
 /obj/structure/railing/handrail/legion{
 	dir = 4
 	},
-/obj/effect/shadow/wall,
 /turf/open/transparent/openspace,
 /area/f13/legion)
 "UG" = (
@@ -15865,7 +16158,9 @@
 /obj/structure/chair/comfy/brown{
 	dir = 1
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3"
+	},
 /area/f13/legion)
 "Vc" = (
 /obj/structure/table/wood/poker,
@@ -15913,7 +16208,7 @@
 /area/f13/building)
 "Vg" = (
 /obj/machinery/door/unpowered/securedoor/legion/warroom,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "Vh" = (
 /obj/structure/window/fulltile/house,
@@ -15927,6 +16222,11 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/red/corner,
 /area/f13/brotherhood/surface)
+"Vj" = (
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
+/area/f13/wasteland)
 "Vk" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/carpet,
@@ -16181,6 +16481,11 @@
 	icon_state = "plating"
 	},
 /area/f13/building)
+"Wb" = (
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3-broken"
+	},
+/area/f13/legion)
 "Wc" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -16258,7 +16563,7 @@
 /area/f13/clinic)
 "Wo" = (
 /obj/machinery/door/unpowered/securedoor/legion/centurion,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "Wp" = (
 /obj/structure/chair,
@@ -16381,7 +16686,14 @@
 /obj/structure/railing/handrail/legion/end{
 	dir = 4
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
+	},
+/area/f13/legion)
+"WM" = (
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor1-broken"
+	},
 /area/f13/legion)
 "WN" = (
 /obj/item/mop,
@@ -16588,7 +16900,7 @@
 /obj/effect/turf_decal/shadow/floor{
 	dir = 8
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "Xz" = (
 /obj/machinery/autolathe,
@@ -16658,6 +16970,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood/f13/oak,
 /area/f13/wasteland)
+"XJ" = (
+/obj/structure/closet/cabinet/anchored,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3"
+	},
+/area/f13/legion)
 "XK" = (
 /obj/effect/decal/cleanable/dirt{
 	color = "000000"
@@ -16686,7 +17004,9 @@
 	},
 /obj/effect/turf_decal/shadow/floor,
 /obj/effect/shadow/wall,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3"
+	},
 /area/f13/legion)
 "XO" = (
 /obj/structure/sign/poster/prewar/poster82,
@@ -16723,7 +17043,9 @@
 	},
 /obj/effect/turf_decal/shadow/floor,
 /obj/effect/shadow/wall,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
+	},
 /area/f13/legion)
 "XX" = (
 /obj/structure/table/reinforced/brass,
@@ -16792,7 +17114,7 @@
 /obj/effect/turf_decal/shadow/floor{
 	dir = 8
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "Yh" = (
 /obj/effect/decal/cleanable/dirt{
@@ -16810,7 +17132,7 @@
 	},
 /obj/effect/turf_decal/shadow/floor,
 /obj/effect/shadow/wall,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "Yj" = (
 /obj/structure/junk/locker,
@@ -16818,6 +17140,14 @@
 	icon_state = "housebase"
 	},
 /area/f13/building)
+"Yk" = (
+/obj/structure/chair/wood{
+	dir = 1
+	},
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
+	},
+/area/f13/legion)
 "Yl" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -16850,7 +17180,9 @@
 /obj/item/radio/headset/headset_legion,
 /obj/item/radio/headset/headset_legion,
 /obj/item/radio/headset/headset_legion,
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
+	},
 /area/f13/legion)
 "Yq" = (
 /obj/effect/decal/cleanable/dirt{
@@ -17051,7 +17383,9 @@
 /obj/structure/railing/handrail/legion{
 	dir = 8
 	},
-/turf/open/floor/f13/wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
 /area/f13/wasteland)
 "YY" = (
 /obj/structure/decoration/rag{
@@ -17130,7 +17464,6 @@
 	dir = 8;
 	light_power = 0.6
 	},
-/obj/effect/shadow/wall,
 /turf/open/transparent/openspace,
 /area/f13/legion)
 "Zn" = (
@@ -17198,6 +17531,14 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/building)
+"Zx" = (
+/obj/structure/railing/handrail/legion/underlayer{
+	dir = 1
+	},
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
+	},
+/area/f13/wasteland)
 "Zy" = (
 /obj/structure/sign/legion/radio,
 /turf/closed/wall/rust,
@@ -76210,8 +76551,8 @@ oE
 wD
 Ma
 YW
-YW
-YW
+uZ
+nG
 JG
 EZ
 EZ
@@ -76446,7 +76787,7 @@ WX
 Cc
 Lk
 FR
-Lk
+MK
 Ba
 WX
 FJ
@@ -76464,7 +76805,7 @@ XN
 Yo
 WX
 Yi
-Cq
+FV
 LQ
 fQ
 Be
@@ -76702,7 +77043,7 @@ EZ
 yE
 dd
 DG
-Cq
+Sq
 Lo
 Bj
 WX
@@ -76718,15 +77059,15 @@ UO
 VJ
 WX
 XW
-Cq
+FV
 WX
-Yi
-Cq
-LQ
-OM
-OM
-OM
-CR
+OX
+SR
+oW
+Vj
+Pj
+lF
+uy
 EZ
 EZ
 kC
@@ -76958,9 +77299,9 @@ EZ
 EZ
 xn
 dm
-DG
+Yk
 FV
-Cq
+Sq
 OR
 WX
 Hm
@@ -76975,15 +77316,15 @@ eI
 xh
 WX
 FG
-Cq
+Lo
 WX
-Yi
-Cq
-LQ
-OM
+OX
+Lo
+dv
+Pj
 Mb
-OM
-CR
+Ts
+fd
 EZ
 EZ
 kC
@@ -77215,10 +77556,10 @@ EZ
 EZ
 WX
 gp
-Cq
-Cq
+FV
+Sq
 ON
-ON
+cw
 WX
 GK
 Tr
@@ -77235,12 +77576,12 @@ RU
 Zy
 WX
 cX
-Cq
+FV
 RJ
-OM
-fQ
-OM
-jn
+Aa
+Nu
+Vj
+uy
 EZ
 EZ
 kC
@@ -77472,10 +77813,10 @@ EZ
 EZ
 xM
 mB
-Cq
-Cq
+Sq
+FV
 wN
-wN
+XJ
 WX
 Id
 UT
@@ -77486,18 +77827,18 @@ WX
 Yz
 Zm
 Cx
-Cq
-Cq
+SR
+FV
 Lo
-Cq
-Cq
-Cq
-Cq
+FV
+Lo
+Sq
+Lo
 PA
-OM
-OM
-Nu
-CR
+Vj
+Pj
+Mb
+fd
 EZ
 EZ
 kC
@@ -77729,10 +78070,10 @@ EZ
 EZ
 xX
 qQ
+Sq
 Cq
-Cq
-ON
-ON
+nM
+cw
 WX
 WX
 WX
@@ -77744,17 +78085,17 @@ RP
 UF
 UR
 WL
-Cq
-Cq
-Cq
-Cq
-Cq
-Cq
+SR
+Sq
+SR
+Lo
+FV
+SR
 rt
-OM
-OM
-OM
-CR
+Vj
+Pj
+Vj
+Qv
 EZ
 EZ
 kC
@@ -77986,32 +78327,32 @@ EZ
 EZ
 Zf
 rf
-DG
-Cq
-Cq
-OR
+jt
+Sq
+SR
+Te
 Db
 Kd
 Or
-Cq
+Sq
 Qs
 Rf
-Rf
+Uy
+pk
 Lk
-Lk
-Lk
-Cq
-FV
-Cq
+xc
+Lo
+SR
+bH
 AQ
 WX
 BZ
-Cq
-LQ
-OM
-hI
-OM
-CR
+Sq
+Zx
+Pj
+Mb
+fQ
+Qv
 EZ
 EZ
 kC
@@ -78243,31 +78584,31 @@ EZ
 EZ
 yE
 rr
-DG
-Cq
-Cq
+Yk
+Sq
+Sq
 Lo
 RU
-Cq
-Cq
-Cq
-Cq
-Cq
-Cq
-Cq
-Cq
+FV
+Sq
+SR
+Lo
+Rz
+CJ
+Rw
+CJ
 TW
-Cq
+Sq
 DO
-Oq
-DG
+sa
+Yk
 WX
-Yi
-Cq
-LQ
-hI
-OM
-OM
+OX
+FV
+dv
+Mb
+lF
+Vj
 uy
 EZ
 EZ
@@ -78500,9 +78841,9 @@ EZ
 EZ
 WX
 rv
-Cq
-Cq
-Cq
+SR
+WM
+Lo
 Cy
 WX
 Uw
@@ -78511,20 +78852,20 @@ sO
 sO
 Rw
 Rz
-sO
-sO
-sO
-sO
+Wb
+TW
+TW
+aC
 Xy
 Yg
 PE
 WX
-Yi
-Cq
-LQ
+wL
+Sq
+oW
 Nu
-OM
-Be
+Vj
+kB
 CR
 EZ
 EZ
@@ -79529,7 +79870,7 @@ CE
 Ks
 rL
 wh
-wh
+Jt
 NY
 Ks
 Di
@@ -79785,13 +80126,13 @@ EZ
 vY
 zs
 nK
-Cq
-Cq
-Cq
+Lo
+Sq
+FV
 Qb
-Cq
-Cq
-Cq
+Lo
+Rz
+CJ
 Vh
 Ra
 EZ
@@ -80042,13 +80383,13 @@ EZ
 vY
 VF
 CL
-Cq
+Sq
 UT
 xD
 Ql
 Dy
-Cq
-Cq
+Rw
+Rz
 Vh
 Ra
 EZ
@@ -80304,8 +80645,8 @@ UT
 yN
 Ks
 RW
-Cq
-Cq
+Rw
+Rz
 VF
 Ra
 EZ
@@ -80556,7 +80897,7 @@ EZ
 aZ
 zr
 CL
-Cq
+SR
 UT
 yX
 Ks
@@ -80812,9 +81153,9 @@ EZ
 EZ
 EZ
 zs
-nK
-Cq
-Cq
+IC
+FV
+Lo
 zY
 Ks
 Fe
@@ -81327,7 +81668,7 @@ EZ
 vY
 Ks
 sB
-Cq
+Lo
 Oq
 Aj
 Ks
@@ -81584,8 +81925,8 @@ EZ
 aZ
 VF
 CZ
-Cq
-Oq
+FV
+cc
 Cx
 Ks
 BY
@@ -81842,8 +82183,8 @@ kC
 Ks
 tb
 wl
-Cq
-Cq
+Sq
+Lo
 Ks
 BY
 BY

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -21887,6 +21887,9 @@
 "jmf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/wood,
+/obj/item/storage/backpack/duffelbag/med/surgery/primitive/anchored{
+	pixel_x = 7
+	},
 /turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "jmn" = (

--- a/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Surface-2.dmm
@@ -2955,8 +2955,7 @@
 /turf/open/water,
 /area/f13/caves)
 "blh" = (
-/obj/structure/table/wood,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/workbench/advanced,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -5909,13 +5908,9 @@
 	},
 /area/f13/building)
 "cCU" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 4
-	},
-/turf/open/floor/wood/f13/oak{
-	icon_state = "oakfloor3"
-	},
+/obj/machinery/smartfridge/bottlerack/wardrobe/legion,
+/obj/effect/turf_decal/shadow/floor,
+/turf/open/floor/wood/f13/oak,
 /area/f13/legion)
 "cDd" = (
 /obj/machinery/light{
@@ -10420,6 +10415,12 @@
 	pixel_x = 15;
 	pixel_y = 18
 	},
+/obj/structure/destructible/tribal_torch/lit{
+	light_power = 0.8;
+	light_range = 5;
+	pixel_x = 9;
+	pixel_y = 17
+	},
 /turf/open/indestructible/ground/inside/dirt/stamped,
 /area/f13/legion)
 "eCM" = (
@@ -10764,7 +10765,6 @@
 /area/f13/building)
 "eKI" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/legionary,
 /turf/open/indestructible/ground/outside/dirt,
 /area/f13/legion)
 "eKN" = (
@@ -10829,10 +10829,15 @@
 /area/f13/building)
 "eLJ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/f13/legionary,
 /obj/structure/decoration/legion/tentpole{
 	pixel_x = 15;
 	pixel_y = 18
+	},
+/obj/structure/destructible/tribal_torch/lit{
+	light_power = 0.8;
+	light_range = 5;
+	pixel_x = 9;
+	pixel_y = 17
 	},
 /turf/open/indestructible/ground/inside/dirt/stamped,
 /area/f13/legion)
@@ -12006,6 +12011,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed/mattress,
 /obj/item/bedsheet/blanket,
+/obj/effect/landmark/start/f13/legionary,
 /turf/open/indestructible/ground/inside/dirt/stamped,
 /area/f13/legion)
 "flw" = (
@@ -12363,6 +12369,7 @@
 "ftz" = (
 /obj/structure/bed/mattress,
 /obj/item/bedsheet/blanket2,
+/obj/effect/landmark/start/f13/legionary,
 /turf/open/indestructible/ground/inside/dirt/stamped,
 /area/f13/legion)
 "ftA" = (
@@ -12376,6 +12383,17 @@
 /obj/item/bedsheet/brown,
 /turf/open/floor/carpet,
 /area/f13/village)
+"ftK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack/shelf_wood,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	light_power = 0.8;
+	pixel_x = 14
+	},
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
+	},
+/area/f13/legion)
 "ftX" = (
 /obj/structure/window/fulltile/wood{
 	max_integrity = 140
@@ -17251,7 +17269,12 @@
 	},
 /area/f13/wasteland)
 "hom" = (
-/obj/structure/campfire/barrel,
+/obj/structure/reagent_dispensers/rainwater_tank{
+	pixel_y = 1
+	},
+/obj/structure/sink/greyscale{
+	pixel_y = -5
+	},
 /turf/open/indestructible/ground/outside/desert/sonora/rough,
 /area/f13/wasteland)
 "hoo" = (
@@ -18191,6 +18214,9 @@
 	amount = 50
 	},
 /obj/effect/turf_decal/shadow/floor,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 4
+	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -20707,7 +20733,7 @@
 /area/f13/clinic)
 "iNw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
+/obj/structure/rack/shelf_wood,
 /turf/open/floor/wood/f13/oak{
 	icon_state = "oakfloor4"
 	},
@@ -21477,6 +21503,7 @@
 /obj/effect/turf_decal/shadow/floor,
 /obj/structure/rack/shelf_wood,
 /obj/effect/shadow/wall,
+/obj/item/shovel,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/legion)
 "jeh" = (
@@ -21526,6 +21553,12 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
+"jfg" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2-broken"
+	},
+/area/f13/legion)
 "jfi" = (
 /obj/item/bedsheet/blanket2,
 /obj/structure/bed/mattress{
@@ -21731,6 +21764,7 @@
 "jjB" = (
 /obj/dugpit,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/flora/wasteplant/wild_fungus,
 /turf/open/indestructible/ground/inside/dirt/stamped/outside/sand{
 	icon_state = "desertsmooth1"
 	},
@@ -21776,6 +21810,15 @@
 	icon_state = "floorrusty"
 	},
 /area/f13/building)
+"jkl" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	pixel_x = -11
+	},
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
+	},
+/area/f13/legion)
 "jkn" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/f13/weapon/gun/tier1,
@@ -25233,6 +25276,12 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
+"kMT" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor3-broken"
+	},
+/area/f13/legion)
 "kMV" = (
 /obj/structure/fence,
 /obj/effect/turf_decal/stripes/white/line{
@@ -26822,9 +26871,9 @@
 	name = "food basket"
 	},
 /obj/effect/spawner/lootdrop/f13/foodspawner,
-/obj/effect/spawner/lootdrop/f13/foodspawner,
 /obj/effect/turf_decal/shadow,
 /obj/item/storage/box/ingredients/carnivore,
+/obj/item/reagent_containers/food/snacks/meatsmoked,
 /turf/open/indestructible/ground/inside/dirt/stamped/outside/sand{
 	dir = 1;
 	icon_state = "desertsmooth7"
@@ -29304,7 +29353,10 @@
 /obj/structure/table/wood,
 /obj/item/stack/sheet/cloth/five,
 /obj/item/stack/sheet/hay/twenty,
-/turf/open/floor/wood/f13/oak,
+/obj/item/stack/sheet/leather/five,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/legion)
 "mES" = (
 /obj/structure/flora/grass/coyote/sixteen,
@@ -34938,6 +34990,12 @@
 /obj/structure/barricade/wooden/planks/pregame,
 /turf/open/indestructible/ground/outside/sidewalk,
 /area/f13/wasteland)
+"pkZ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4-broken"
+	},
+/area/f13/legion)
 "plf" = (
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
@@ -35245,7 +35303,6 @@
 	},
 /area/f13/wasteland)
 "psg" = (
-/obj/structure/destructible/tribal_torch/lit,
 /obj/structure/decoration/legion/tentpole{
 	pixel_x = -16
 	},
@@ -36005,17 +36062,6 @@
 	icon_state = "horizontaltopborderbottom2left"
 	},
 /area/f13/wasteland)
-"pJZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/guncase{
-	anchored = 1
-	},
-/obj/item/gun/ballistic/rifle/repeater/cowboy,
-/obj/item/gun/ballistic/rifle/repeater/cowboy,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/legion)
 "pKj" = (
 /obj/structure/cargocrate,
 /obj/structure/cargocrate{
@@ -39666,11 +39712,11 @@
 /turf/open/floor/wood/f13/oak,
 /area/f13/building)
 "rBd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/structure/sign/legion/veteran,
-/turf/open/floor/wood/f13/oak{
-	icon_state = "oakfloor4"
+/obj/machinery/autolathe/ammo/unlocked,
+/obj/item/stack/ore/blackpowder/twenty,
+/obj/item/stack/ore/blackpowder/twenty,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
 	},
 /area/f13/legion)
 "rBs" = (
@@ -44701,13 +44747,10 @@
 	},
 /area/f13/building)
 "tOV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 4
-	},
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
+/obj/structure/bed/mattress,
+/obj/item/bedsheet/blanket,
+/obj/effect/landmark/start/f13/legionary,
+/turf/open/indestructible/ground/inside/dirt/stamped,
 /area/f13/legion)
 "tOW" = (
 /obj/structure/closet,
@@ -45275,13 +45318,15 @@
 /area/f13/caves)
 "udx" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 1;
-	light_power = 0.9;
-	pixel_x = 1;
-	pixel_y = -20
+/obj/structure/sign/legion/armory{
+	pixel_x = -31
 	},
-/turf/open/floor/wood/f13/oak,
+/obj/structure/destructible/tribal_torch/wall/lit{
+	dir = 8
+	},
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor4"
+	},
 /area/f13/legion)
 "udA" = (
 /obj/effect/decal/marking{
@@ -46655,7 +46700,9 @@
 /area/f13/legion)
 "uGH" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/unpowered/secure_legion,
+/obj/structure/table,
+/obj/item/ammo_box/shotgun/buck,
+/obj/item/ammo_box/shotgun/buck,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -46744,7 +46791,6 @@
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "uJC" = (
-/obj/structure/destructible/tribal_torch/lit,
 /obj/structure/decoration/legion/tentpole{
 	pixel_x = -16
 	},
@@ -47489,9 +47535,8 @@
 "vbC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
-/obj/structure/sign/poster/contraband/revolver{
-	pixel_y = 31
-	},
+/obj/item/ammo_box/tube/a357,
+/obj/item/ammo_box/tube/a357,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -47922,6 +47967,12 @@
 	icon_state = "verticalleftborderrightbottom"
 	},
 /area/f13/wasteland)
+"vnj" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor1-broken"
+	},
+/area/f13/legion)
 "vns" = (
 /obj/structure/sign/departments/medbay,
 /turf/closed/wall/f13/store,
@@ -48275,12 +48326,8 @@
 /area/f13/building)
 "vxs" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/spawner/bundle/f13/revolver45,
-/obj/effect/spawner/bundle/f13/revolver45,
-/obj/effect/spawner/bundle/f13/revolver45,
-/obj/structure/guncase{
-	anchored = 1
-	},
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/f13/blueprintLow,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -48478,10 +48525,9 @@
 /area/f13/building)
 "vDe" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/barricade/bars,
-/obj/structure/barricade/wooden/strong,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
+/obj/structure/rack/shelf_wood,
+/turf/open/floor/wood/f13/oak{
+	icon_state = "oakfloor2"
 	},
 /area/f13/legion)
 "vDg" = (
@@ -48627,9 +48673,7 @@
 	},
 /area/f13/building)
 "vGw" = (
-/obj/structure/rack/shelf_metal{
-	name = "stacking storage shelves"
-	},
+/obj/structure/rack/shelf_wood,
 /obj/item/stack/sheet/glass/ten,
 /obj/item/stack/sheet/metal{
 	amount = 50
@@ -48968,7 +49012,10 @@
 	},
 /area/f13/building)
 "vPA" = (
-/obj/structure/destructible/tribal_torch/lit,
+/obj/structure/destructible/tribal_torch/lit{
+	light_power = 0.8;
+	light_range = 5
+	},
 /turf/open/indestructible/ground/inside/dirt/stamped,
 /area/f13/legion)
 "vPF" = (
@@ -49526,12 +49573,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/f13/brotherhood/surface)
-"wgg" = (
-/obj/machinery/workbench/advanced,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/legion)
 "wgj" = (
 /obj/effect/turf_decal/arrows{
 	dir = 4;
@@ -49750,9 +49791,11 @@
 /area/f13/wasteland)
 "wlP" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/ammo_box/shotgun/buck,
-/obj/item/ammo_box/shotgun/buck,
+/obj/structure/guncase{
+	anchored = 1
+	},
+/obj/item/gun/ballistic/shotgun/hunting,
+/obj/item/gun/ballistic/shotgun/hunting,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -49792,17 +49835,6 @@
 /obj/structure/barricade/wooden/strong,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"wnf" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/guncase{
-	anchored = 1
-	},
-/obj/item/gun/ballistic/shotgun/hunting,
-/obj/item/gun/ballistic/shotgun/hunting,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/legion)
 "wnn" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/f13/vault_floor/neutral/white,
@@ -49937,14 +49969,6 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/caves)
-"wqe" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table/wood,
-/obj/effect/spawner/lootdrop/f13/blueprintLow,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/legion)
 "wqk" = (
 /obj/structure/sign/poster/prewar/poster63{
 	pixel_x = -32;
@@ -50020,11 +50044,10 @@
 /area/f13/clinic)
 "wte" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/structure/destructible/tribal_torch/wall/lit{
-	dir = 8;
-	light_power = 0.8;
-	pixel_y = -21
+/obj/effect/spawner/bundle/f13/revolver45,
+/obj/effect/spawner/bundle/f13/revolver45,
+/obj/structure/guncase{
+	anchored = 1
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
@@ -50310,14 +50333,6 @@
 /obj/structure/chair/office/dark,
 /turf/open/floor/plasteel/f13/vault_floor/white/whitesolid,
 /area/f13/building)
-"wzV" = (
-/obj/machinery/autolathe/ammo/unlocked,
-/obj/item/stack/ore/blackpowder/twenty,
-/obj/item/stack/ore/blackpowder/twenty,
-/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
-	color = "#e4e4e4"
-	},
-/area/f13/legion)
 "wAt" = (
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel/darkblue/corner,
@@ -51027,7 +51042,6 @@
 /area/f13/building)
 "wPS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/destructible/tribal_torch/lit,
 /obj/effect/shadow/wall,
 /turf/open/indestructible/ground/inside/dirt/stamped,
 /area/f13/legion)
@@ -51510,9 +51524,11 @@
 /area/f13/building)
 "wZQ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/ammo_box/tube/a357,
-/obj/item/ammo_box/tube/a357,
+/obj/structure/guncase{
+	anchored = 1
+	},
+/obj/item/gun/ballistic/rifle/repeater/cowboy,
+/obj/item/gun/ballistic/rifle/repeater/cowboy,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
 	color = "#e4e4e4"
 	},
@@ -53178,11 +53194,6 @@
 	icon_state = "bluerustychess2"
 	},
 /area/f13/building)
-"xIu" = (
-/obj/machinery/smartfridge/bottlerack/wardrobe/legion,
-/obj/effect/turf_decal/shadow/floor,
-/turf/open/floor/wood/f13/oak,
-/area/f13/legion)
 "xIv" = (
 /obj/machinery/microwave,
 /obj/structure/table/booth,
@@ -53961,11 +53972,6 @@
 	icon_state = "whitegreenrustychess"
 	},
 /area/f13/building)
-"ybg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/legion/armory,
-/turf/closed/wall/rust,
-/area/f13/legion)
 "ybh" = (
 /obj/structure/chair/stool{
 	dir = 1;
@@ -98423,7 +98429,7 @@ ggK
 ggK
 ggK
 ggK
-rFN
+ggK
 ggK
 gcK
 gcK
@@ -103048,7 +103054,7 @@ fyf
 fyf
 fyf
 fyf
-fyf
+wjt
 fyf
 boY
 gcK
@@ -113598,7 +113604,7 @@ sfK
 tgo
 gRq
 wCd
-xFO
+udx
 vbC
 wte
 wlP
@@ -113832,7 +113838,7 @@ ktB
 xoK
 cKZ
 nBQ
-pQb
+fTc
 fle
 xoK
 hbU
@@ -113855,8 +113861,8 @@ smx
 gRq
 gJZ
 wCd
+pkZ
 uGH
-xLu
 xLu
 xLu
 xLu
@@ -114109,14 +114115,14 @@ uVy
 uVy
 uVy
 spn
-wCd
+jfg
 uFt
 uFt
+gRq
+gRq
+gJZ
+gRq
 vDe
-vxs
-xLu
-wnf
-pJZ
 xFO
 xSd
 uas
@@ -114347,7 +114353,7 @@ xoK
 xip
 pQb
 eKI
-uNh
+tOV
 xoK
 xBC
 uFt
@@ -114368,12 +114374,12 @@ rAI
 bEq
 iNw
 uFt
-udx
-ybg
-vDe
-uGH
-vDe
-vDe
+gRq
+gRq
+wCd
+jfg
+wCd
+ftK
 xFO
 xFO
 aOE
@@ -114880,7 +114886,7 @@ uVy
 xLu
 xLu
 xzs
-xIu
+gJZ
 gJZ
 wCd
 wCd
@@ -115137,14 +115143,14 @@ uVy
 xLu
 rGv
 xzs
-thK
-xLu
-gJZ
-wzV
-vGw
-wgg
-wqe
+cCU
 wCd
+jfg
+uFt
+uFt
+kMT
+gJZ
+jkl
 xFO
 xFO
 bqO
@@ -115375,7 +115381,7 @@ xoK
 wPS
 fTc
 seR
-vPA
+fTc
 xoK
 hNc
 wCd
@@ -115398,10 +115404,10 @@ thK
 xLu
 wCd
 xLu
-xLu
+vxs
 xLu
 blh
-gJZ
+xLu
 xFO
 wIN
 whO
@@ -115652,13 +115658,13 @@ pGS
 plf
 iDW
 hHB
-tOV
+xLu
 gRq
 rBd
 mEN
-wCd
-gRq
-cCU
+xLu
+vGw
+xLu
 xFO
 xVt
 whO
@@ -115909,12 +115915,12 @@ xFO
 xFO
 xFO
 xFO
-xFO
+whU
 qPq
 uUS
-xFO
 whU
 whU
+uUS
 xFO
 xFO
 xWl
@@ -117191,7 +117197,7 @@ fLs
 wCd
 nRw
 sqz
-uFt
+vnj
 svP
 oYb
 duN
@@ -117445,7 +117451,7 @@ vIP
 vDU
 wQg
 wCd
-uFt
+jfg
 qQP
 sqz
 wCd
@@ -117655,7 +117661,7 @@ gcK
 gcK
 gcK
 gcK
-fyf
+coD
 fyf
 fyf
 fyf

--- a/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
+++ b/_maps/map_files/Pahrump/Pahrump-Underground-1.dmm
@@ -202,8 +202,14 @@
 	},
 /area/f13/sewer)
 "agL" = (
-/obj/structure/ore_box,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/structure/rack/shelf_metal,
+/obj/item/pickaxe,
+/obj/item/pickaxe,
+/obj/item/storage/bag/ore,
+/obj/item/storage/bag/ore,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/tunnel)
 "agO" = (
 /obj/machinery/defibrillator_mount/loaded{
@@ -1228,8 +1234,8 @@
 	pixel_y = 6
 	},
 /obj/item/paper{
-	info = "Got the godforsaken power working down here. Apparently if you jam it in there good, the fusion cells from gunny's armor can fit in the power box. Below's how to replace the cell when it runs dry.<br><b>Step 1<br>Unlock cover in interface.<br>Step 2<br> Pry cell with crowbar.<br><b>Step 3<br>Add new cell.</b><br><br>-Private Barnes";
 	icon_state = "paper_words";
+	info = "Got the godforsaken power working down here. Apparently if you jam it in there good, the fusion cells from gunny's armor can fit in the power box. Below's how to replace the cell when it runs dry.<br><b>Step 1<br>Unlock cover in interface.<br>Step 2<br> Pry cell with crowbar.<br><b>Step 3<br>Add new cell.</b><br><br>-Private Barnes";
 	name = "power box instructions"
 	},
 /obj/item/crowbar/basic,
@@ -2438,8 +2444,8 @@
 /area/f13/den)
 "bGa" = (
 /obj/item/trash/f13/porknbeans{
-	pixel_y = 23;
-	pixel_x = 12
+	pixel_x = 12;
+	pixel_y = 23
 	},
 /obj/machinery/light/small{
 	dir = 1;
@@ -7822,8 +7828,8 @@
 /area/f13/enclave)
 "fcS" = (
 /obj/machinery/door/airlock/vault{
-	req_access_txt = "134";
-	id_tag = "enclavehatch"
+	id_tag = "enclavehatch";
+	req_access_txt = "134"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
@@ -7967,9 +7973,9 @@
 "fhn" = (
 /obj/structure/bed/mattress,
 /obj/item/radio/intercom{
+	frequency = 1292;
 	pixel_x = 32;
-	pixel_y = 2;
-	frequency = 1292
+	pixel_y = 2
 	},
 /obj/effect/landmark/start/f13/uslt,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -14613,8 +14619,11 @@
 /turf/open/floor/plasteel/f13/vault_floor/plating,
 /area/f13/bunker)
 "jYE" = (
-/obj/item/candle/tribal_torch,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/structure/rack/shelf_metal,
+/obj/item/stack/sheet/coke/twenty,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/tunnel)
 "jYR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -15653,9 +15662,9 @@
 /area/f13/enclave)
 "kQN" = (
 /obj/item/radio/tribal{
-	pixel_y = 11;
 	desc = "an old pre-war radio transceiver somehow still working after all this time.";
-	name = "old radio"
+	name = "old radio";
+	pixel_y = 11
 	},
 /obj/structure/table/rolling,
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
@@ -16992,15 +17001,15 @@
 /area/f13/bunker)
 "lXU" = (
 /obj/item/reagent_containers/food/snacks/beans{
-	pixel_y = 20;
-	pixel_x = -5
+	pixel_x = -5;
+	pixel_y = 20
 	},
 /obj/structure/rack/shelf_metal{
 	pixel_x = 4
 	},
 /obj/item/flashlight/glowstick{
-	pixel_y = 12;
-	pixel_x = 13
+	pixel_x = 13;
+	pixel_y = 12
 	},
 /obj/item/flashlight/glowstick/yellow{
 	pixel_x = 9;
@@ -17396,6 +17405,9 @@
 	icon_state = "bluerustysolid"
 	},
 /area/f13/brotherhood/archives)
+"mpV" = (
+/turf/closed/mineral/random/protective_area,
+/area/f13/caves)
 "mro" = (
 /obj/machinery/light,
 /turf/open/floor/carpet/red,
@@ -20140,8 +20152,8 @@
 /obj/structure/barricade/bars,
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters{
-	max_integrity = 300;
-	id = "enclave_shutter"
+	id = "enclave_shutter";
+	max_integrity = 300
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
@@ -22258,6 +22270,12 @@
 	icon_state = "tunnelrusty"
 	},
 /area/f13/enclave)
+"qxy" = (
+/obj/structure/ore_box,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
+/area/f13/tunnel)
 "qxN" = (
 /obj/item/radio/intercom{
 	frequency = 1361;
@@ -22509,6 +22527,13 @@
 "qGM" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/structure/barricade/wooden/strong,
+/turf/open/indestructible/ground/inside/mountain,
+/area/f13/tunnel)
+"qGO" = (
+/obj/structure/destructible/tribal_torch/lit{
+	light_power = 0.8;
+	light_range = 5
+	},
 /turf/open/indestructible/ground/inside/mountain,
 /area/f13/tunnel)
 "qGX" = (
@@ -24297,9 +24322,10 @@
 /turf/open/floor/carpet/red,
 /area/f13/den)
 "rTo" = (
-/obj/item/storage/bag/ore,
-/obj/item/pickaxe,
-/turf/open/indestructible/ground/inside/mountain,
+/obj/structure/blacksmith/furnace/sandstone,
+/turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust{
+	color = "#e4e4e4"
+	},
 /area/f13/tunnel)
 "rTW" = (
 /obj/effect/decal/remains{
@@ -24602,10 +24628,10 @@
 /area/f13/caves)
 "sgP" = (
 /obj/machinery/button{
-	pixel_x = 24;
-	pixel_y = 24;
 	id = "enclave_shutter";
-	name = "shutter button"
+	name = "shutter button";
+	pixel_x = 24;
+	pixel_y = 24
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
@@ -26543,8 +26569,8 @@
 /area/f13/tcoms)
 "tNP" = (
 /obj/structure/ladder/unbreakable{
-	id = "enclave_bunker";
-	height = 2
+	height = 2;
+	id = "enclave_bunker"
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
@@ -27715,18 +27741,18 @@
 /area/f13/enclave)
 "uRF" = (
 /obj/structure/junk/small/tv{
-	pixel_y = 9;
-	pixel_x = -3
+	pixel_x = -3;
+	pixel_y = 9
 	},
 /obj/structure/table/booth,
 /obj/item/reagent_containers/food/drinks/bottle/brown/beer{
-	pixel_y = 7;
-	pixel_x = 10
+	pixel_x = 10;
+	pixel_y = 7
 	},
 /obj/machinery/light/small,
 /obj/item/clothing/head/f13/enclave{
-	pixel_y = 18;
-	pixel_x = -9
+	pixel_x = -9;
+	pixel_y = 18
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
@@ -27787,17 +27813,17 @@
 	},
 /obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45d{
 	anchored = 1;
-	pixel_y = 10;
-	name = "display T-45d helmet";
 	armor = list("melee"=0,"bullet"=0,"laser"=0,"energy"=0,"bomb"=0,"bio"=0,"rad"=0,"fire"=0,"acid"=0,"wound"=0);
-	desc = "Upon closer inspection, this T-45d power armor helmet appears to be fake."
+	desc = "Upon closer inspection, this T-45d power armor helmet appears to be fake.";
+	name = "display T-45d helmet";
+	pixel_y = 10
 	},
 /obj/item/clothing/suit/armored/heavy/salvaged_pa/t45d{
 	anchored = 1;
-	pixel_x = -1;
-	pixel_y = 2;
+	desc = "Upon closer inspection, this T-45d power armor appears to be fake.";
 	name = "display T-45d power armor";
-	desc = "Upon closer inspection, this T-45d power armor appears to be fake."
+	pixel_x = -1;
+	pixel_y = 2
 	},
 /turf/open/indestructible/ground/inside/subway{
 	name = "stone floor"
@@ -28417,19 +28443,19 @@
 	},
 /obj/item/clothing/suit/armored/heavy/salvaged_pa/t51b{
 	anchored = 1;
-	pixel_x = -1;
-	pixel_y = 3;
-	name = "displayT-51b power armor";
 	armor = list("melee"=0,"bullet"=0,"laser"=0,"energy"=0,"bomb"=0,"bio"=0,"rad"=0,"fire"=0,"acid"=0,"wound"=0);
-	desc = "Upon closer inspection, this T-51b power armor appears to be fake."
+	desc = "Upon closer inspection, this T-51b power armor appears to be fake.";
+	name = "displayT-51b power armor";
+	pixel_x = -1;
+	pixel_y = 3
 	},
 /obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t51b{
 	anchored = 1;
-	pixel_x = -1;
-	pixel_y = 11;
+	armor = list("melee"=0,"bullet"=0,"laser"=0,"energy"=0,"bomb"=0,"bio"=0,"rad"=0,"fire"=0,"acid"=0,"wound"=0);
 	desc = "Upon closer inspection, this T-51b power armor helmet appears to be fake.";
 	name = "display T-51b power armor";
-	armor = list("melee"=0,"bullet"=0,"laser"=0,"energy"=0,"bomb"=0,"bio"=0,"rad"=0,"fire"=0,"acid"=0,"wound"=0)
+	pixel_x = -1;
+	pixel_y = 11
 	},
 /turf/open/indestructible/ground/inside/subway{
 	name = "stone floor"
@@ -29013,17 +29039,17 @@
 	},
 /obj/item/clothing/suit/armored/heavy/salvaged_pa/t45d{
 	anchored = 1;
-	pixel_x = -1;
-	pixel_y = 2;
+	desc = "Upon closer inspection, this T-45d power armor appears to be fake.";
 	name = "display T-45d power armor";
-	desc = "Upon closer inspection, this T-45d power armor appears to be fake."
+	pixel_x = -1;
+	pixel_y = 2
 	},
 /obj/item/clothing/head/helmet/f13/heavy/salvaged_pa/t45d{
 	anchored = 1;
-	pixel_y = 10;
-	name = "display T-45d helmet";
 	armor = list("melee"=0,"bullet"=0,"laser"=0,"energy"=0,"bomb"=0,"bio"=0,"rad"=0,"fire"=0,"acid"=0,"wound"=0);
-	desc = "Upon closer inspection, this T-45d power armor helmet appears to be fake."
+	desc = "Upon closer inspection, this T-45d power armor helmet appears to be fake.";
+	name = "display T-45d helmet";
+	pixel_y = 10
 	},
 /turf/open/indestructible/ground/inside/subway{
 	name = "stone floor"
@@ -29070,12 +29096,12 @@
 	pixel_x = 16
 	},
 /obj/structure/bed{
-	pixel_y = 16;
-	pixel_x = 2
+	pixel_x = 2;
+	pixel_y = 16
 	},
 /obj/machinery/computer/security/bos{
-	pixel_y = 15;
-	pixel_x = -3
+	pixel_x = -3;
+	pixel_y = 15
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
@@ -29111,8 +29137,8 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	pixel_x = 32;
-	frequency = 1291
+	frequency = 1291;
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
@@ -29319,10 +29345,10 @@
 /area/f13/den)
 "vUa" = (
 /obj/machinery/button{
-	pixel_x = 7;
-	pixel_y = 24;
 	id = "enclavehatch";
-	name = "hatch bolts button"
+	name = "hatch bolts button";
+	pixel_x = 7;
+	pixel_y = 24
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/vaultrust,
 /area/f13/enclave)
@@ -77955,9 +77981,9 @@ vPg
 vPg
 vPg
 vPg
-aoj
-aoj
-aoj
+mpV
+mpV
+mpV
 eLE
 vPg
 vPg
@@ -78211,7 +78237,7 @@ tur
 vPg
 vPg
 vPg
-vPg
+mpV
 vPg
 vPg
 vPg
@@ -78467,10 +78493,10 @@ hpW
 tur
 vPg
 vPg
+mpV
 vPg
 vPg
-vPg
-vPg
+aoj
 vPg
 vPg
 vPg
@@ -78724,7 +78750,7 @@ lfk
 tur
 vPg
 vPg
-vPg
+mpV
 vPg
 vPg
 vPg
@@ -78981,11 +79007,11 @@ dxj
 tur
 vPg
 vPg
+mpV
 vPg
 vPg
 vPg
-vPg
-vPg
+aoj
 vPg
 vPg
 vPg
@@ -80270,7 +80296,7 @@ evI
 wFD
 evI
 vPg
-vPg
+mpV
 vPg
 vPg
 aoj
@@ -80527,7 +80553,7 @@ evI
 evI
 vPg
 vPg
-vPg
+mpV
 vPg
 aoj
 aoj
@@ -80783,7 +80809,7 @@ vPg
 vPg
 vPg
 vPg
-vPg
+mpV
 vPg
 vPg
 vPg
@@ -81034,12 +81060,12 @@ eLE
 eLE
 eLE
 eLE
-vPg
-vPg
-aoj
-aoj
-vPg
-vPg
+mpV
+mpV
+mpV
+mpV
+mpV
+mpV
 vPg
 vPg
 vPg
@@ -82322,7 +82348,7 @@ eLE
 eLE
 eLE
 eLE
-eLE
+vPg
 vPg
 vPg
 vPg
@@ -83868,7 +83894,7 @@ eLE
 vPg
 vPg
 vPg
-aoj
+vPg
 aoj
 aoj
 aoj
@@ -84378,7 +84404,7 @@ vPg
 vPg
 vPg
 eLE
-eLE
+vPg
 vPg
 vPg
 vPg
@@ -84635,7 +84661,7 @@ vPg
 vPg
 vPg
 eLE
-vPg
+aoj
 vPg
 vPg
 vPg
@@ -87203,7 +87229,7 @@ vPg
 vPg
 vPg
 vPg
-vPg
+eLE
 eLE
 vPg
 vPg
@@ -87461,7 +87487,7 @@ eLE
 eLE
 eLE
 eLE
-eLE
+vPg
 vPg
 vPg
 vPg
@@ -87710,12 +87736,12 @@ raD
 lPf
 fvo
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
 eLE
+vPg
+vPg
+vPg
+vPg
+aoj
 vPg
 vPg
 vPg
@@ -87967,12 +87993,12 @@ raD
 qRM
 fvo
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
 eLE
+vPg
+vPg
+aoj
+aoj
+aoj
 vPg
 vPg
 vPg
@@ -88225,11 +88251,11 @@ vPg
 vPg
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
 eLE
+eLE
+eLE
+vPg
+vPg
 vPg
 vPg
 vPg
@@ -88485,8 +88511,8 @@ vPg
 vPg
 vPg
 vPg
-vPg
 eLE
+vPg
 vPg
 vPg
 vPg
@@ -89009,7 +89035,7 @@ aoj
 vPg
 vPg
 aoj
-aoj
+vPg
 aoj
 aoj
 aoj
@@ -90811,7 +90837,7 @@ aoj
 aoj
 aoj
 aoj
-aoj
+vPg
 vPg
 vPg
 vPg
@@ -91540,7 +91566,7 @@ eLE
 eLE
 vPg
 vPg
-aoj
+vPg
 aoj
 vPg
 vPg
@@ -92307,7 +92333,7 @@ eSW
 eLE
 vPg
 vPg
-vPg
+aoj
 vPg
 vPg
 vPg
@@ -92564,11 +92590,11 @@ eLE
 eLE
 vPg
 vPg
+aoj
 vPg
 vPg
 vPg
-vPg
-vPg
+aoj
 vPg
 vPg
 vPg
@@ -92819,19 +92845,19 @@ weC
 eSW
 eLE
 eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
-eLE
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
 vPg
 vPg
 aoj
@@ -92848,13 +92874,13 @@ vPg
 vPg
 aoj
 aoj
-aoj
-aoj
-aoj
-aoj
-vPg
 vPg
 aoj
+aoj
+aoj
+vPg
+vPg
+aoj
 vPg
 vPg
 vPg
@@ -92870,7 +92896,7 @@ vPg
 vPg
 vPg
 vPg
-vPg
+aoj
 eLE
 "}
 (237,1,1) = {"
@@ -93081,14 +93107,14 @@ vPg
 vPg
 vPg
 vPg
-vPg
-vPg
-vPg
+eLE
+eLE
+eLE
 vPg
 aoj
 vPg
 vPg
-eLE
+vPg
 vPg
 vPg
 vPg
@@ -93334,18 +93360,18 @@ xwr
 eLE
 vPg
 vPg
+aoj
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
+eLE
 vPg
 vPg
 vPg
 eLE
+eLE
+aoj
+aoj
+vPg
 vPg
 vPg
 vPg
@@ -93589,20 +93615,20 @@ ojd
 xwr
 xwr
 eLE
+eLE
 vPg
 vPg
-vPg
-vPg
-vPg
+eLE
+eLE
 vPg
 vPg
 lnr
 vPg
 vPg
 vPg
-vPg
-aoj
 eLE
+aoj
+vPg
 vPg
 vPg
 vPg
@@ -93847,8 +93873,8 @@ uWA
 eSW
 eLE
 vPg
-vPg
-vPg
+eLE
+eLE
 vPg
 vPg
 vPg
@@ -93856,10 +93882,10 @@ lnr
 lnr
 nBk
 nBk
-vPg
-vPg
 vPg
 eLE
+vPg
+vPg
 vPg
 vPg
 vPg
@@ -94115,8 +94141,8 @@ lnr
 nBk
 vPg
 vPg
-vPg
 eLE
+vPg
 vPg
 aoj
 vPg
@@ -95657,15 +95683,15 @@ vPg
 vPg
 vPg
 vPg
-vPg
 eLE
+vPg
 aoj
 vPg
 vPg
 vPg
 aoj
 aoj
-aoj
+vPg
 aoj
 aoj
 aoj
@@ -95910,12 +95936,12 @@ vVD
 tmM
 vPg
 vPg
-aoj
-aoj
-vPg
-vPg
-vPg
 eLE
+eLE
+eLE
+eLE
+vPg
+vPg
 aoj
 vPg
 vPg
@@ -96166,30 +96192,30 @@ tVE
 mRl
 tmM
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
 eLE
-aoj
 vPg
 vPg
-aoj
 vPg
-aoj
-aoj
-aoj
-aoj
-aoj
 vPg
 vPg
 vPg
 aoj
 vPg
 vPg
+aoj
 vPg
+aoj
+aoj
+aoj
+aoj
+aoj
+vPg
+vPg
+vPg
+aoj
+vPg
+vPg
+lnr
 vPg
 vPg
 vPg
@@ -96423,14 +96449,14 @@ fgu
 nJG
 tmM
 vPg
-vPg
-vPg
-vPg
-vPg
-aoj
-vPg
 eLE
 vPg
+vPg
+vPg
+aoj
+vPg
+vPg
+vPg
 aoj
 aoj
 vPg
@@ -96440,14 +96466,14 @@ aoj
 aoj
 aoj
 aoj
-vPg
 vPg
 vPg
 vPg
 vPg
 vPg
 jYE
-vPg
+lnr
+lnr
 vPg
 vPg
 eLE
@@ -96680,15 +96706,15 @@ tmM
 tmM
 xLe
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
 eLE
 vPg
 vPg
+vPg
+aoj
+vPg
+vPg
+vPg
+vPg
 aoj
 aoj
 aoj
@@ -96702,10 +96728,10 @@ aoj
 vPg
 aoj
 vPg
+rTo
 lnr
+qGO
 lnr
-lnr
-rJA
 vPg
 vPg
 vPg
@@ -96937,13 +96963,13 @@ vPg
 vPg
 vPg
 vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
 eLE
+vPg
+vPg
+aoj
+aoj
+vPg
+vPg
 vPg
 vPg
 aoj
@@ -97193,21 +97219,21 @@ eLE
 eLE
 eLE
 eLE
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
-vPg
 eLE
 vPg
 vPg
 aoj
+vPg
+vPg
+vPg
+vPg
+vPg
+vPg
 aoj
 aoj
 aoj
 aoj
+aoj
 vPg
 vPg
 vPg
@@ -97216,15 +97242,15 @@ vPg
 vPg
 vPg
 vPg
-vPg
-rTo
+qxy
+lnr
 ldM
 vPg
 vPg
 vPg
 vPg
 vPg
-vPg
+aoj
 vPg
 eLE
 hgA
@@ -97457,14 +97483,14 @@ vPg
 vPg
 vPg
 vPg
-eLE
+vPg
 vPg
 vPg
 aoj
 aoj
+vPg
 aoj
 aoj
-aoj
 vPg
 vPg
 vPg
@@ -97473,8 +97499,8 @@ vPg
 vPg
 vPg
 vPg
-vPg
-vPg
+qxy
+lnr
 vPg
 vPg
 vPg

--- a/code/game/objects/items/melee/f13onehanded.dm
+++ b/code/game/objects/items/melee/f13onehanded.dm
@@ -136,7 +136,7 @@
 	throwforce = 35
 	armour_penetration = 0.10
 	max_reach = 2
-	embedding = list("pain_mult" = 4, "embed_chance" = 60, "fall_chance" = 20)
+	embedding = list("pain_mult" = 4, "embed_chance" = 65, "fall_chance" = 8)
 	w_class = WEIGHT_CLASS_NORMAL
 
 

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -121,7 +121,7 @@
 	var/datum/component/storage/concrete/stack/STR = GetComponent(/datum/component/storage/concrete/stack)
 	STR.allow_quick_empty = TRUE
 	STR.max_items = 14
-	STR.can_hold = typecacheof(list(/obj/item/stack/ore))
+	STR.can_hold = typecacheof(list(/obj/item/stack/ore, /obj/item/stack/sheet/mineral/limestone))
 	STR.max_w_class = WEIGHT_CLASS_HUGE
 	STR.max_combined_stack_amount = 50
 

--- a/code/game/objects/items/storage/f13storage.dm
+++ b/code/game/objects/items/storage/f13storage.dm
@@ -476,7 +476,7 @@
 	icon_state = "medicinebox_simple"
 	illustration = "overlay_powder"
 
-/obj/item/storage/box/medicine/poultice5/PopulateContents()
+/obj/item/storage/box/medicine/powder5/PopulateContents()
 	. = ..()
 	new /obj/item/reagent_containers/pill/patch/healingpowder(src)
 	new /obj/item/reagent_containers/pill/patch/healingpowder(src)

--- a/code/modules/research/designs/autolathe_desings/autolathe_designs_medical_and_dinnerware.dm
+++ b/code/modules/research/designs/autolathe_desings/autolathe_designs_medical_and_dinnerware.dm
@@ -192,8 +192,8 @@
 /datum/design/healthanalyzer
 	name = "Health Analyzer"
 	id = "healthanalyzer"
-	build_type = AUTOLATHE | PROTOLATHE | NO_PUBLIC_LATHE
-	materials = list(/datum/material/iron = 500, /datum/material/glass = 50)
+	build_type = AUTOLATHE | PROTOLATHE | NO_PUBLIC_LATHE | AUTOLATHE_PRIMITIVE
+	materials = list(/datum/material/iron = 500, /datum/material/glass = 1000)
 	build_path = /obj/item/healthanalyzer
 	category = list("initial", "Medical")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL

--- a/modular_BD2/blacksmith/code/finished_items.dm
+++ b/modular_BD2/blacksmith/code/finished_items.dm
@@ -793,7 +793,7 @@
 	force = FORCE_SMITH_REACH
 	armour_penetration = PIERCING_MODERATE
 	sharpness = SHARP_POINTY
-	embedding = list("pain_mult" = 2, "embed_chance" = 62, "fall_chance" = 20, "ignore_throwspeed_threshold" = TRUE)
+	embedding = list("pain_mult" = 2, "embed_chance" = 62, "fall_chance" = 8, "ignore_throwspeed_threshold" = TRUE)
 
 // ------------ THROWING KNIFE ------------ // [Embed]
 /obj/item/melee/smith/throwingknife
@@ -803,7 +803,7 @@
 	item_state = "dagger_smith"
 	force = FORCE_SMITH_REACH
 	armour_penetration = PIERCING_MINOR
-	embedding = list("pain_mult" = 2, "embed_chance" = 65, "fall_chance" = 20, "ignore_throwspeed_threshold" = TRUE)
+	embedding = list("pain_mult" = 2, "embed_chance" = 65, "fall_chance" = 8, "ignore_throwspeed_threshold" = TRUE)
 	w_class = WEIGHT_CLASS_SMALL
 
 // ------------ METAL BOLA ------------ //

--- a/modular_BD2/blacksmith/code/furnace.dm
+++ b/modular_BD2/blacksmith/code/furnace.dm
@@ -2,7 +2,7 @@
 
 /obj/structure/blacksmith/furnace
 	name = "furnace"
-	desc = "A furnace with fume protection and good ventilation for stoking the fire. Used for heating metal ingots or smelting ores into sheets."
+	desc = "A furnace with fume protection and good ventilation for stoking the fire. Used for heating metal ingots or smelting ores into sheets. Can be fueled with coke or welder fuel."
 	icon = 'modular_BD2/blacksmith/icons/furnace32x64.dmi'
 	icon_state = "furnace"
 	density = TRUE
@@ -105,6 +105,6 @@
 
 /obj/structure/blacksmith/furnace/sandstone // can be built from sandstone, less economical but same effect
 	name = "sandstone furnace"
-	desc = "A simply made furnace, not as fuel-efficient as more advanced ones. Used for heating metal ingots."
+	desc = "A simply made furnace, not as fuel-efficient as more advanced ones. Used for heating metal ingots or smelting ores. Can be fueled with coke or welder fuel."
 	icon = 'modular_BD2/blacksmith/icons/furnace_sandstone32x64.dmi'
 	fueluse = 2

--- a/modular_BD2/general/code/modular_BD2.dm
+++ b/modular_BD2/general/code/modular_BD2.dm
@@ -28,7 +28,7 @@
 
 /obj/item/stack/ore/coal // turns to coke when heated in a Furnace or ORM
 	name = "coal"
-	desc = "Pure coal needs heat-processing to become good fuel."
+	desc = "Pure coal needs heat-processing to become efficient fuel."
 	icon = 'modular_BD2/general/icons/stackable_items.dmi'
 	icon_state = "ore_coal"
 	singular_name = "lump of coal"
@@ -40,7 +40,7 @@
 
 /obj/item/stack/sheet/coke // Can be used to fuel Furnaces, Campfires, Barrel Fires, Potbelly stoves, Fireplaces, or grind for charcoal
 	name = "coke"
-	desc = "Coke is what you get when you heat-treat coal. It's a good fuel for burning."
+	desc = "Coke is what you get when you heat-treat coal. It's a good fuel for burning, use it in furnaces, grills, potbelly stoves and so on."
 	singular_name = "bag of coke"
 	icon = 'modular_BD2/general/icons/stackable_items.dmi'
 	icon_state = "sheet_coke"


### PR DESCRIPTION
## About The Pull Request

Noticed couple things that needed sorting post-mapping.
* Powder 5 box fixed
* Added a third water source for Legion camp with a literal sink attached since brainlets seems to have issues finding the other two. If they cant find this one the entire camp deserves to die of thirst anyways.
* Mine updated southeast, a bit more accessible areas, less square, smelting station added, randomized protected area turfs added to the highway into the mine so theres a degree of uncertainty again if you can mine in or not that way.
* Armory in Legion camp a little more open, just deleted the pointless wall around the guns and slightly shifted some tiles, less congested now.
* Some floorings switched out/added in camp, minimal cosmetics but a bunch of lines.
* Descs added to help players understand that coke can be used as fuel too
* Health analyzer added to the lathe options, almost every tool other than that can either be crafted like always or is already present in camp, use brain or don't and suffer, matters not.
* Limestone now scooped by mining satchel
* added adjustment of the throwing spear, still worse than the throwing knife but not by much, lets see how it plays out ingame, should be good.